### PR TITLE
Rename Header to Heading; deprecate old one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ github_flavored_markdown
 [![Build Status](https://travis-ci.org/shurcooL/github_flavored_markdown.svg?branch=master)](https://travis-ci.org/shurcooL/github_flavored_markdown) [![GoDoc](https://godoc.org/github.com/shurcooL/github_flavored_markdown?status.svg)](https://godoc.org/github.com/shurcooL/github_flavored_markdown)
 
 Package github_flavored_markdown provides a GitHub Flavored Markdown renderer
-with fenced code block highlighting, clickable header anchor links.
+with fenced code block highlighting, clickable heading anchor links.
 
 The functionality should be equivalent to the GitHub Markdown API endpoint specified at
 https://developer.github.com/v3/markdown/#render-a-markdown-document-in-raw-mode, except

--- a/gfmstyle/assets_vfsdata.go
+++ b/gfmstyle/assets_vfsdata.go
@@ -148,9 +148,6 @@ func (f *vfsgen۰CompressedFile) Close() error {
 	return f.gr.Close()
 }
 
-// We already imported "bytes", but ended up not using it. Avoid unused import error.
-var _ = bytes.Reader{}
-
 // vfsgen۰DirInfo is a static definition of a directory.
 type vfsgen۰DirInfo struct {
 	name    string

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 /*
 Package github_flavored_markdown provides a GitHub Flavored Markdown renderer
-with fenced code block highlighting, clickable header anchor links.
+with fenced code block highlighting, clickable heading anchor links.
 
 The functionality should be equivalent to the GitHub Markdown API endpoint specified at
 https://developer.github.com/v3/markdown/#render-a-markdown-document-in-raw-mode, except
@@ -39,11 +39,11 @@ func Markdown(text []byte) []byte {
 	return sanitized
 }
 
-// Header returns a header HTML node with title text.
-// The header comes with an anchor based on the title.
+// Heading returns a heading HTML node with title text.
+// The heading comes with an anchor based on the title.
 //
-// header can be one of atom.H1, atom.H2, atom.H3, atom.H4, atom.H5, atom.H6.
-func Header(header atom.Atom, title string) *html.Node {
+// heading can be one of atom.H1, atom.H2, atom.H3, atom.H4, atom.H5, atom.H6.
+func Heading(heading atom.Atom, title string) *html.Node {
 	aName := sanitized_anchor_name.Create(title)
 	a := &html.Node{
 		Type: html.ElementNode, Data: atom.A.String(),
@@ -57,14 +57,25 @@ func Header(header atom.Atom, title string) *html.Node {
 	}
 	span := &html.Node{
 		Type: html.ElementNode, Data: atom.Span.String(),
-		Attr:       []html.Attribute{{Key: atom.Class.String(), Val: "octicon-link"}}, // TODO: Factor out the CSS for just headers.
+		Attr:       []html.Attribute{{Key: atom.Class.String(), Val: "octicon-link"}}, // TODO: Factor out the CSS for just headings.
 		FirstChild: octiconssvg.Link(),
 	}
 	a.AppendChild(span)
-	h := &html.Node{Type: html.ElementNode, Data: header.String()}
+	h := &html.Node{Type: html.ElementNode, Data: heading.String()}
 	h.AppendChild(a)
 	h.AppendChild(&html.Node{Type: html.TextNode, Data: title})
 	return h
+}
+
+// Header returns a heading HTML node with title text.
+// The heading comes with an anchor based on the title.
+//
+// heading can be one of atom.H1, atom.H2, atom.H3, atom.H4, atom.H5, atom.H6.
+//
+// Deprecated: Use Heading instead. This function was renamed to that, and will be deleted soon.
+func Header(heading atom.Atom, title string) *html.Node {
+	// TODO: Remove this deprecated func after 2017-02-24.
+	return Heading(heading, title)
 }
 
 // extensions for GitHub Flavored Markdown-like parsing.
@@ -93,7 +104,7 @@ type renderer struct {
 	*blackfriday.Html
 }
 
-// GitHub Flavored Markdown header with clickable and hidden anchor.
+// GitHub Flavored Markdown heading with clickable and hidden anchor.
 func (*renderer) Header(out *bytes.Buffer, text func() bool, level int, _ string) {
 	marker := out.Len()
 	doubleSpace(out)
@@ -106,7 +117,7 @@ func (*renderer) Header(out *bytes.Buffer, text func() bool, level int, _ string
 	textHTML := out.String()[marker:]
 	out.Truncate(marker)
 
-	// Extract text content of the header.
+	// Extract text content of the heading.
 	var textContent string
 	if node, err := html.Parse(strings.NewReader(textHTML)); err == nil {
 		textContent = extractText(node)

--- a/main_test.go
+++ b/main_test.go
@@ -46,12 +46,12 @@ func TestComponents(t *testing.T) {
 		want string
 	}{
 		{
-			// Header.
+			// Heading.
 			text: "## git diff",
 			want: `<h2><a name="git-diff" class="anchor" href="#git-diff" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>git diff</h2>` + "\n",
 		},
 		{
-			// Header Link.
+			// Heading Link.
 			text: "### [Some **bold** _italic_ link](http://www.example.com)",
 			want: `<h3><a name="some-bold-italic-link" class="anchor" href="#some-bold-italic-link" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a><a href="http://www.example.com" rel="nofollow">Some <strong>bold</strong> <em>italic</em> link</a></h3>` + "\n",
 		},
@@ -91,9 +91,9 @@ func TestComponents(t *testing.T) {
 	}
 }
 
-func ExampleHeader() {
-	header := github_flavored_markdown.Header(atom.H2, "Hello > Goodbye")
-	html.Render(os.Stdout, header)
+func ExampleHeading() {
+	heading := github_flavored_markdown.Heading(atom.H2, "Hello > Goodbye")
+	html.Render(os.Stdout, heading)
 
 	// Output:
 	// <h2><a name="hello-goodbye" class="anchor" href="#hello-goodbye" rel="nofollow" aria-hidden="true"><span class="octicon-link"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" style="fill: currentColor; vertical-align: top;"><path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></span></a>Hello &gt; Goodbye</h2>


### PR DESCRIPTION
Heading seems like a more appropriate name, given that elements \<h1\> through \<h6\> stand for "heading" (see HTMLHeadingElement), not "header" (as I originally mistakenly thought). There is a \<header\> element in HTML5, but that's usually a higher level container that contains a few headings and a paragraph.

This func returns a \<h1\>-\<h6\> element. Based on that, heading seems like a more appropriate name.

> The HTML \<h1\>–\<h6\> elements represent six levels of section headings.
> \<h1\> is the highest section level and \<h6\> is the lowest.

> The HTML \<header\> element represents a group of introductory or
> navigational aids. It may contain some heading elements but also other
> elements like a logo, a search form, and so on.

Sources:

-	https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements
-	https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header

The old deprecated Heading will be removed after 2 weeks.

Regenerate with latest version of vfsgen.