### PR TITLE
use gopkg.in to make buildable with go modules and dep

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ import (
 	"text/template"
 
 	"github.com/microcosm-cc/bluemonday"
-	"github.com/russross/blackfriday"
 	"github.com/shurcooL/highlight_diff"
 	"github.com/shurcooL/highlight_go"
 	"github.com/shurcooL/octicon"
@@ -28,6 +27,7 @@ import (
 	"github.com/sourcegraph/syntaxhighlight"
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
+	blackfriday "gopkg.in/russross/blackfriday.v1"
 )
 
 // Markdown renders GitHub Flavored Markdown text.

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/microcosm-cc/bluemonday"
-	"github.com/russross/blackfriday"
+	blackfriday "gopkg.in/russross/blackfriday.v1"
 )
 
 // In this test, nothing should be sanitized away.


### PR DESCRIPTION
Currently when trying to use this package with either Go modules in `1.11` or in a `dep` environment, the package doesn't build. This change uses the `gopkg.in` version of the `russross/blackfriday` project to ensure that the correct version of `blackfriday` is used.