### PR TITLE
Add minimal go.mod, go.sum.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/shurcooL/github_flavored_markdown
+
+require github.com/russross/blackfriday v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
+github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=


### PR DESCRIPTION
The intention is to make it so that it's possible to import and use this package from within Go modules (in addition to the well-supported GOPATH workspace mode), and have it build without users having to manually specify that github_flavored_markdown requires blackfriday v1.

Use the recently created blackfriday [v1.5.2](https://github.com/russross/blackfriday/releases/tag/v1.5.2) tag.

Only specify the blackfriday version in go.mod and go.sum; others are unspecified to avoid the added burden of maintaining and updating them.

Updates #12.
Updates #20.

/cc @markbates @rtfb @bep